### PR TITLE
VESC driver robustification

### DIFF
--- a/lib/VescDriver/VescDriver.cpp
+++ b/lib/VescDriver/VescDriver.cpp
@@ -58,7 +58,7 @@ void VescDriver::processInput()
 
 size_t VescDriver::sendPacket(const uint8_t *payload, const uint16_t payload_length)
 {
-	if (payload_length > MAXIMUM_PAYLOAD_LENGTH) {
+	if (payload_length == 0 || payload_length > MAXIMUM_PAYLOAD_LENGTH) {
 		return 0;
 	}
 
@@ -92,7 +92,6 @@ size_t VescDriver::sendPacket(const uint8_t *payload, const uint16_t payload_len
 
 void VescDriver::parsePayload(const uint8_t *payload, const uint16_t payload_length)
 {
-	//printf("ID: %d Size: %d\n", payload[0], payload_length);
 	uint16_t index{1};
 	switch (payload[0]) {
 	case VescCommand::FW_VERSION:
@@ -155,6 +154,10 @@ void VescDriver::parseInputByte(uint8_t byte)
 		if (_input_start_byte == 2) {
 			// Short packet
 			_input_payload_length = byte;
+
+			if (_input_payload_length < 1) {
+				_input_byte_index = 0;
+			}
 		} else {
 			// Long packet high byte
 			_input_payload_length = byte << 8;
@@ -165,7 +168,7 @@ void VescDriver::parseInputByte(uint8_t byte)
 		_input_payload_length |= byte;
 		_input_byte_index++;
 
-		if (_input_payload_length > MAXIMUM_PAYLOAD_LENGTH) {
+		if (_input_payload_length < 255 || _input_payload_length > MAXIMUM_PAYLOAD_LENGTH) {
 			_input_byte_index = 0;
 		}
 

--- a/lib/VescDriver/VescDriver.cpp
+++ b/lib/VescDriver/VescDriver.cpp
@@ -45,17 +45,6 @@ void VescDriver::requestValues()
 	sendPacket(&command, 1);
 }
 
-void VescDriver::processInput()
-{
-	size_t length_to_read{1};
-	uint8_t buffer_input[length_to_read];
-	size_t length_read = read(buffer_input, length_to_read);
-	//printf("length read: %d\n", length_read);
-	for (size_t i = 0; i < length_read; i++) {
-		parseInputByte(buffer_input[i]);
-	}
-}
-
 size_t VescDriver::sendPacket(const uint8_t *payload, const uint16_t payload_length)
 {
 	if (payload_length == 0 || payload_length > MAXIMUM_PAYLOAD_LENGTH) {
@@ -88,54 +77,6 @@ size_t VescDriver::sendPacket(const uint8_t *payload, const uint16_t payload_len
 	packet_buffer[index++] = 3;
 
 	return write(packet_buffer, index);
-}
-
-void VescDriver::parsePayload(const uint8_t *payload, const uint16_t payload_length)
-{
-	uint16_t index{1};
-	switch (payload[0]) {
-	case VescCommand::FW_VERSION:
-		if (payload_length >= 9u) {
-			_vesc_version.version_major = payload[index++];
-			_vesc_version.version_minor = payload[index++];
-			// strcpy(_vesc_version.hardware_name, reinterpret_cast<const char *>(&payload[index]));
-			// index += strlen(_vesc_version.hardware_name) + 1u;
-			// memcpy(_vesc_version.stm32_uuid_8, &payload[index], sizeof(_vesc_version.stm32_uuid_8));
-			// index += 12;
-			// _vesc_version.pairing_done = payload[index++];
-			// _vesc_version.test_version_number = payload[index++];
-			// _vesc_version.hardware_type = payload[index++];
-			// _vesc_version.custom_configuration = payload[index++];
-		}
-		break;
-	case VescCommand::GET_VALUES:
-		if (payload_length >= 73u) {
-			_vesc_values.fet_temperature = extractFloat16(payload, index) / 10.f;
-			_vesc_values.motor_temperature = extractFloat16(payload, index) / 10.f;
-			_vesc_values.motor_current = extractFloat32(payload, index) / 100.f;
-			_vesc_values.input_current = extractFloat32(payload, index) / 100.f;
-			_vesc_values.reset_average_id = extractFloat32(payload, index) / 100.f;
-			_vesc_values.reset_average_iq = extractFloat32(payload, index) / 100.f;
-			_vesc_values.duty_cycle = extractFloat16(payload, index) / 1000.f;
-			_vesc_values.rpm = extractInt32(payload, index);
-			_vesc_values.input_voltage = extractFloat16(payload, index) / 10.f;
-			_vesc_values.used_charge_Ah = extractFloat32(payload, index) / 1e4f;
-			_vesc_values.charged_charge_Ah = extractFloat32(payload, index) / 1e4f;
-			_vesc_values.used_energy_Wh = extractFloat32(payload, index) / 1e4f;
-			_vesc_values.charged_energy_wh = extractFloat32(payload, index) / 10.f;
-			_vesc_values.tachometer = extractInt32(payload, index);
-			_vesc_values.tachometer_absolute = extractInt32(payload, index);
-			_vesc_values.fault = payload[index++];
-			_vesc_values.position_pid = extractFloat32(payload, index) / 1e6f;
-			_vesc_values.controller_id = payload[index++];
-			_vesc_values.ntc_temperature_mos1 = extractFloat16(payload, index) / 10.f;
-			_vesc_values.ntc_temperature_mos2 = extractFloat16(payload, index) / 10.f;
-			_vesc_values.ntc_temperature_mos3 = extractFloat16(payload, index) / 10.f;
-			_vesc_values.read_reset_average_vd = extractFloat32(payload, index) / 1000.f;
-			_vesc_values.read_reset_average_vq = extractFloat32(payload, index) / 1000.f;
-		}
-		break;
-	}
 }
 
 void VescDriver::parseInputByte(uint8_t byte)
@@ -201,6 +142,54 @@ void VescDriver::parseInputByte(uint8_t byte)
 	}
 }
 
+void VescDriver::parsePayload(const uint8_t *payload, const uint16_t payload_length)
+{
+	uint16_t index{1};
+	switch (payload[0]) {
+	case VescCommand::FW_VERSION:
+		if (payload_length >= 9u) {
+			_vesc_version.version_major = payload[index++];
+			_vesc_version.version_minor = payload[index++];
+			// strcpy(_vesc_version.hardware_name, reinterpret_cast<const char *>(&payload[index]));
+			// index += strlen(_vesc_version.hardware_name) + 1u;
+			// memcpy(_vesc_version.stm32_uuid_8, &payload[index], sizeof(_vesc_version.stm32_uuid_8));
+			// index += 12;
+			// _vesc_version.pairing_done = payload[index++];
+			// _vesc_version.test_version_number = payload[index++];
+			// _vesc_version.hardware_type = payload[index++];
+			// _vesc_version.custom_configuration = payload[index++];
+		}
+		break;
+	case VescCommand::GET_VALUES:
+		if (payload_length >= 73u) {
+			_vesc_values.fet_temperature = extractFloat16(payload, index) / 10.f;
+			_vesc_values.motor_temperature = extractFloat16(payload, index) / 10.f;
+			_vesc_values.motor_current = extractFloat32(payload, index) / 100.f;
+			_vesc_values.input_current = extractFloat32(payload, index) / 100.f;
+			_vesc_values.reset_average_id = extractFloat32(payload, index) / 100.f;
+			_vesc_values.reset_average_iq = extractFloat32(payload, index) / 100.f;
+			_vesc_values.duty_cycle = extractFloat16(payload, index) / 1000.f;
+			_vesc_values.rpm = extractInt32(payload, index);
+			_vesc_values.input_voltage = extractFloat16(payload, index) / 10.f;
+			_vesc_values.used_charge_Ah = extractFloat32(payload, index) / 1e4f;
+			_vesc_values.charged_charge_Ah = extractFloat32(payload, index) / 1e4f;
+			_vesc_values.used_energy_Wh = extractFloat32(payload, index) / 1e4f;
+			_vesc_values.charged_energy_wh = extractFloat32(payload, index) / 10.f;
+			_vesc_values.tachometer = extractInt32(payload, index);
+			_vesc_values.tachometer_absolute = extractInt32(payload, index);
+			_vesc_values.fault = payload[index++];
+			_vesc_values.position_pid = extractFloat32(payload, index) / 1e6f;
+			_vesc_values.controller_id = payload[index++];
+			_vesc_values.ntc_temperature_mos1 = extractFloat16(payload, index) / 10.f;
+			_vesc_values.ntc_temperature_mos2 = extractFloat16(payload, index) / 10.f;
+			_vesc_values.ntc_temperature_mos3 = extractFloat16(payload, index) / 10.f;
+			_vesc_values.read_reset_average_vd = extractFloat32(payload, index) / 1000.f;
+			_vesc_values.read_reset_average_vq = extractFloat32(payload, index) / 1000.f;
+		}
+		break;
+	}
+}
+
 uint16_t VescDriver::crc16(const uint8_t *buffer, const uint16_t length)
 {
 	uint16_t checksum{0};
@@ -245,9 +234,4 @@ float VescDriver::extractFloat32(const uint8_t *buffer, uint16_t &index)
 
 size_t VescDriver::write(const uint8_t *buffer, const uint16_t length) {
 	return fwrite(buffer, sizeof(uint8_t), length, _device);
-}
-
-
-size_t VescDriver::read(uint8_t *buffer, const uint16_t length) {
-	return fread(buffer, sizeof(uint8_t), length, _device);
 }

--- a/lib/VescDriver/VescDriver.cpp
+++ b/lib/VescDriver/VescDriver.cpp
@@ -142,7 +142,7 @@ void VescDriver::parseInputByte(uint8_t byte)
 {
 	if (_input_byte_index == 0) {
 		// Start byte
-		if (byte == 2 || byte == 3) {
+		if (byte == 2 /*|| byte == 3*/) {
 			_input_start_byte = byte;
 			_input_byte_index++;
 		}

--- a/lib/VescDriver/VescDriver.hpp
+++ b/lib/VescDriver/VescDriver.hpp
@@ -35,13 +35,12 @@ public:
 	float getRpm() { return _vesc_values.rpm; };
 	float getInputVoltage() { return _vesc_values.input_voltage; };
 
-	void processInput(); ///< call when data is ready to read
+	void parseInputByte(uint8_t byte); ///< call when data is ready to read
 
 private:
 	// de-/serialize packets
 	size_t sendPacket(const uint8_t *payload, const uint16_t payload_length);
 	void parsePayload(const uint8_t *payload, const uint16_t payload_length);
-	void parseInputByte(uint8_t byte);
 	uint16_t crc16(const uint8_t *buffer, const uint16_t length);
 
 	// big-endian helpers
@@ -53,7 +52,6 @@ private:
 
 	// byte stream access through _device
 	size_t write(const uint8_t *buffer, const uint16_t length);
-	size_t read(uint8_t *buffer, const uint16_t length);
 
 	FILE *_device;
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -28,7 +28,7 @@ static constexpr PinName PEDAL_INTERRUPT_PIN{PC_6};
 static constexpr int UPDATE_FREQUENCY_HZ{10};
 volatile bool is_pedal_interrupt_to_handle{false};
 
-void pedal_interrup_callback()
+void pedal_interrupt_callback()
 {
 	is_pedal_interrupt_to_handle = true;
 }
@@ -46,7 +46,7 @@ int main() {
 	VescDriver vesc_motor(fdopen(&vesc2_uart, "r+b"));
 
 	InterruptIn pedal_interrupt(PEDAL_INTERRUPT_PIN);
-	pedal_interrupt.fall(&pedal_interrup_callback);
+	pedal_interrupt.fall(&pedal_interrupt_callback);
 
 	// Application start
 	printf("Coilchain v0.1\n");

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -59,20 +59,24 @@ int main() {
 			char letter{};
 			computer.read(&letter, 1);
 
-			if (letter == 'q' && current < 5.f) {
+			switch (letter) {
+			case 'q':
 				current += .1f;
-			}
-
-			if (letter == 'a' && current > .0f) {
+				current = current > 5.f ? 5.f : current;
+				break;
+			case 'a':
 				current -= .1f;
-			}
-
-			if (letter == 'v') {
+				current = current < 0.f ? 0.f : current;
+				break;
+			case 's':
+				current = 0.f;
+				break;
+			case 'v':
 				vesc_generator.requestFirmwareVersion();
-			}
-
-			if (letter == 't') {
+				break;
+			case 't':
 				vesc_generator.requestValues();
+				break;
 			}
 
 			printf("Voltage: %.3f\n", vesc_generator.getInputVoltage());

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -86,7 +86,10 @@ int main()
 		vesc_generator.commandCurrent(current);
 
 		while (vesc1_uart.readable()) {
-			vesc_generator.processInput();
+			uint8_t byte;
+			if (vesc1_uart.read(&byte, 1)) {
+				vesc_generator.parseInputByte(byte);
+			}
 		}
 
 		// Handle pedal interrupt

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -19,13 +19,19 @@
 
 #include "VescDriver.hpp"
 
+static constexpr int UPDATE_FREQUENCY_HZ{10};
 static constexpr PinName VESC1_TX_PIN{PA_11};
 static constexpr PinName VESC1_RX_PIN{PA_12};
 static constexpr PinName VESC2_TX_PIN{PB_6};
 static constexpr PinName VESC2_RX_PIN{PB_7};
 static constexpr PinName PEDAL_INTERRUPT_PIN{PC_6};
 
-static constexpr int UPDATE_FREQUENCY_HZ{10};
+// Hardware initalization
+static DigitalOut led(LED1);
+static BufferedSerial computer(USBTX, USBRX, 9600);
+static BufferedSerial vesc1_uart(VESC1_TX_PIN, VESC1_RX_PIN, 115200);
+static BufferedSerial vesc2_uart(VESC2_TX_PIN, VESC2_RX_PIN, 115200);
+
 volatile bool is_pedal_interrupt_to_handle{false};
 
 void pedal_interrupt_callback()
@@ -33,17 +39,10 @@ void pedal_interrupt_callback()
 	is_pedal_interrupt_to_handle = true;
 }
 
-int main() {
-	// Hardware initalization
-	DigitalOut led(LED1);
-
-	BufferedSerial computer(USBTX, USBRX, 9600);
-
-	BufferedSerial vesc1_uart(VESC1_TX_PIN, VESC1_RX_PIN, 115200);
+int main()
+{
 	vesc1_uart.set_blocking(false);
 	VescDriver vesc_generator(fdopen(&vesc1_uart, "r+b"));
-
-	BufferedSerial vesc2_uart(VESC2_TX_PIN, VESC2_RX_PIN, 115200);
 	VescDriver vesc_motor(fdopen(&vesc2_uart, "r+b"));
 
 	InterruptIn pedal_interrupt(PEDAL_INTERRUPT_PIN);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -40,6 +40,7 @@ int main() {
 	BufferedSerial computer(USBTX, USBRX, 9600);
 
 	BufferedSerial vesc1_uart(VESC1_TX_PIN, VESC1_RX_PIN, 115200);
+	vesc1_uart.set_blocking(false);
 	VescDriver vesc_generator(fdopen(&vesc1_uart, "r+b"));
 
 	BufferedSerial vesc2_uart(VESC2_TX_PIN, VESC2_RX_PIN, 115200);


### PR DESCRIPTION
While trying to do some basic data processing with the VESC I realized that there's corner cases where packet loss can occur. This pr works around multiple of these issues. The most significant being:
- large packet handling detecting the stop byte as start byte leading to a lot of packet misses: 4087896
- The usage of the supported BufferedSerial interface `FILE * f = fdopen((BufferedSerial*), "r+b")` that can lead to **corrupted bytes** through `fgetc(f)` and `fread(buffer, sizeof(uint8_t), length, f)` for unkown reason: a024272