### PR TITLE
VescDriver: get selective telemtry values

### DIFF
--- a/lib/VescDriver/VescDriver.cpp
+++ b/lib/VescDriver/VescDriver.cpp
@@ -144,7 +144,7 @@ void VescDriver::parseInputByte(uint8_t byte)
 
 void VescDriver::parsePayload(const uint8_t *payload, const uint16_t payload_length)
 {
-	uint16_t index{1};
+	uint16_t index{1u};
 	switch (payload[0]) {
 	case VescCommand::FW_VERSION:
 		if (payload_length >= 9u) {
@@ -161,31 +161,36 @@ void VescDriver::parsePayload(const uint8_t *payload, const uint16_t payload_len
 		}
 		break;
 	case VescCommand::GET_VALUES:
-		if (payload_length >= 73u) {
-			_vesc_values.fet_temperature = extractFloat16(payload, index) / 10.f;
-			_vesc_values.motor_temperature = extractFloat16(payload, index) / 10.f;
-			_vesc_values.motor_current = extractFloat32(payload, index) / 100.f;
-			_vesc_values.input_current = extractFloat32(payload, index) / 100.f;
-			_vesc_values.reset_average_id = extractFloat32(payload, index) / 100.f;
-			_vesc_values.reset_average_iq = extractFloat32(payload, index) / 100.f;
-			_vesc_values.duty_cycle = extractFloat16(payload, index) / 1000.f;
-			_vesc_values.rpm = extractInt32(payload, index);
-			_vesc_values.input_voltage = extractFloat16(payload, index) / 10.f;
-			_vesc_values.used_charge_Ah = extractFloat32(payload, index) / 1e4f;
-			_vesc_values.charged_charge_Ah = extractFloat32(payload, index) / 1e4f;
-			_vesc_values.used_energy_Wh = extractFloat32(payload, index) / 1e4f;
-			_vesc_values.charged_energy_wh = extractFloat32(payload, index) / 10.f;
-			_vesc_values.tachometer = extractInt32(payload, index);
-			_vesc_values.tachometer_absolute = extractInt32(payload, index);
-			_vesc_values.fault = payload[index++];
-			_vesc_values.position_pid = extractFloat32(payload, index) / 1e6f;
-			_vesc_values.controller_id = payload[index++];
-			_vesc_values.ntc_temperature_mos1 = extractFloat16(payload, index) / 10.f;
-			_vesc_values.ntc_temperature_mos2 = extractFloat16(payload, index) / 10.f;
-			_vesc_values.ntc_temperature_mos3 = extractFloat16(payload, index) / 10.f;
-			_vesc_values.read_reset_average_vd = extractFloat32(payload, index) / 1000.f;
-			_vesc_values.read_reset_average_vq = extractFloat32(payload, index) / 1000.f;
+	case VescCommand::GET_VALUES_SELECTIVE:
+		uint32_t mask = 0xFFFFFFFF; // all values for GET_VALUES
+		uint8_t mask_index{0u};
+		if (payload[0] == VescCommand::GET_VALUES_SELECTIVE) {
+			mask = extractUInt32(payload, index); // selected values for GET_VALUES_SELECTIVE
 		}
+
+		if (mask & static_cast<uint32_t>(1 << mask_index++)) _vesc_values.fet_temperature = extractFloat16(payload, index) / 10.f;
+		if (mask & static_cast<uint32_t>(1 << mask_index++)) _vesc_values.motor_temperature = extractFloat16(payload, index) / 10.f;
+		if (mask & static_cast<uint32_t>(1 << mask_index++)) _vesc_values.motor_current = extractFloat32(payload, index) / 100.f;
+		if (mask & static_cast<uint32_t>(1 << mask_index++)) _vesc_values.input_current = extractFloat32(payload, index) / 100.f;
+		if (mask & static_cast<uint32_t>(1 << mask_index++)) _vesc_values.reset_average_id = extractFloat32(payload, index) / 100.f;
+		if (mask & static_cast<uint32_t>(1 << mask_index++)) _vesc_values.reset_average_iq = extractFloat32(payload, index) / 100.f;
+		if (mask & static_cast<uint32_t>(1 << mask_index++)) _vesc_values.duty_cycle = extractFloat16(payload, index) / 1000.f;
+		if (mask & static_cast<uint32_t>(1 << mask_index++)) _vesc_values.rpm = extractInt32(payload, index);
+		if (mask & static_cast<uint32_t>(1 << mask_index++)) _vesc_values.input_voltage = extractFloat16(payload, index) / 10.f;
+		if (mask & static_cast<uint32_t>(1 << mask_index++)) _vesc_values.used_charge_Ah = extractFloat32(payload, index) / 1e4f;
+		if (mask & static_cast<uint32_t>(1 << mask_index++)) _vesc_values.charged_charge_Ah = extractFloat32(payload, index) / 1e4f;
+		if (mask & static_cast<uint32_t>(1 << mask_index++)) _vesc_values.used_energy_Wh = extractFloat32(payload, index) / 1e4f;
+		if (mask & static_cast<uint32_t>(1 << mask_index++)) _vesc_values.charged_energy_wh = extractFloat32(payload, index) / 10.f;
+		if (mask & static_cast<uint32_t>(1 << mask_index++)) _vesc_values.tachometer = extractInt32(payload, index);
+		if (mask & static_cast<uint32_t>(1 << mask_index++)) _vesc_values.tachometer_absolute = extractInt32(payload, index);
+		if (mask & static_cast<uint32_t>(1 << mask_index++)) _vesc_values.fault = payload[index++];
+		if (mask & static_cast<uint32_t>(1 << mask_index++)) _vesc_values.position_pid = extractFloat32(payload, index) / 1e6f;
+		if (mask & static_cast<uint32_t>(1 << mask_index++)) _vesc_values.controller_id = payload[index++];
+		if (mask & static_cast<uint32_t>(1 << mask_index++)) _vesc_values.ntc_temperature_mos1 = extractFloat16(payload, index) / 10.f;
+		if (mask & static_cast<uint32_t>(1 << mask_index++)) _vesc_values.ntc_temperature_mos2 = extractFloat16(payload, index) / 10.f;
+		if (mask & static_cast<uint32_t>(1 << mask_index++)) _vesc_values.ntc_temperature_mos3 = extractFloat16(payload, index) / 10.f;
+		if (mask & static_cast<uint32_t>(1 << mask_index++)) _vesc_values.read_reset_average_vd = extractFloat32(payload, index) / 1000.f;
+		if (mask & static_cast<uint32_t>(1 << mask_index++)) _vesc_values.read_reset_average_vq = extractFloat32(payload, index) / 1000.f;
 		break;
 	}
 }
@@ -230,6 +235,12 @@ int32_t VescDriver::extractInt32(const uint8_t *buffer, uint16_t &index)
 float VescDriver::extractFloat32(const uint8_t *buffer, uint16_t &index)
 {
 	return static_cast<float>(extractInt32(buffer, index));
+}
+
+uint32_t VescDriver::extractUInt32(const uint8_t *buffer, uint16_t &index)
+{
+	index += 4;
+	return static_cast<uint32_t>(buffer[index - 4] << 24 | buffer[index - 3] << 16 | buffer[index - 2] << 8 | buffer[index - 1]);
 }
 
 size_t VescDriver::write(const uint8_t *buffer, const uint16_t length) {

--- a/lib/VescDriver/VescDriver.cpp
+++ b/lib/VescDriver/VescDriver.cpp
@@ -20,29 +20,37 @@
 void VescDriver::commandCurrent(float current)
 {
 	uint8_t command[5]{VescCommand::SET_CURRENT};
-	uint16_t index{1};
+	uint16_t index{1u};
 	insertInt32(command, index, static_cast<int32_t>(current * 1000.f));
-	sendPacket(command, 5);
+	sendPacket(command, 5u);
 }
 
 void VescDriver::commandBrakeCurrent(float current)
 {
 	uint8_t command[5]{VescCommand::SET_CURRENT_BRAKE};
-	uint16_t index{1};
+	uint16_t index{1u};
 	insertInt32(command, index, static_cast<int32_t>(current * 1000.f));
-	sendPacket(command, 5);
+	sendPacket(command, 5u);
 }
 
 void VescDriver::requestFirmwareVersion()
 {
 	uint8_t command{VescCommand::FW_VERSION};
-	sendPacket(&command, 1);
+	sendPacket(&command, 1u);
 }
 
 void VescDriver::requestValues()
 {
 	uint8_t command{VescCommand::GET_VALUES};
-	sendPacket(&command, 1);
+	sendPacket(&command, 1u);
+}
+
+void VescDriver::requestRpm()
+{
+	uint8_t command[5]{VescCommand::GET_VALUES_SELECTIVE};
+	uint16_t index{1};
+	insertUInt32(command, index, 0x80);
+	sendPacket(command, 5u);
 }
 
 size_t VescDriver::sendPacket(const uint8_t *payload, const uint16_t payload_length)
@@ -143,7 +151,7 @@ void VescDriver::parseInputByte(uint8_t byte)
 }
 
 void VescDriver::parsePayload(const uint8_t *payload, const uint16_t payload_length)
-{
+{	
 	uint16_t index{1u};
 	switch (payload[0]) {
 	case VescCommand::FW_VERSION:
@@ -208,6 +216,14 @@ uint16_t VescDriver::crc16(const uint8_t *buffer, const uint16_t length)
 }
 
 void VescDriver::insertInt32(uint8_t *buffer, uint16_t &index, int32_t value)
+{
+	buffer[index++] = value >> 24;
+	buffer[index++] = value >> 16;
+	buffer[index++] = value >> 8;
+	buffer[index++] = value;
+}
+
+void VescDriver::insertUInt32(uint8_t *buffer, uint16_t &index, uint32_t value)
 {
 	buffer[index++] = value >> 24;
 	buffer[index++] = value >> 16;

--- a/lib/VescDriver/VescDriver.hpp
+++ b/lib/VescDriver/VescDriver.hpp
@@ -49,6 +49,7 @@ private:
 	float extractFloat16(const uint8_t *buffer, uint16_t &index);
 	int32_t extractInt32(const uint8_t *buffer, uint16_t &index);
 	float extractFloat32(const uint8_t *buffer, uint16_t &index);
+	uint32_t extractUInt32(const uint8_t *buffer, uint16_t &index);
 
 	// byte stream access through _device
 	size_t write(const uint8_t *buffer, const uint16_t length);

--- a/lib/VescDriver/VescDriver.hpp
+++ b/lib/VescDriver/VescDriver.hpp
@@ -32,6 +32,7 @@ public:
 
 	void requestFirmwareVersion();
 	void requestValues();
+	void requestRpm();
 	float getRpm() { return _vesc_values.rpm; };
 	float getInputVoltage() { return _vesc_values.input_voltage; };
 
@@ -45,6 +46,7 @@ private:
 
 	// big-endian helpers
 	void insertInt32(uint8_t *buffer, uint16_t &index, int32_t value);
+	void insertUInt32(uint8_t *buffer, uint16_t &index, uint32_t value);
 	int16_t extractInt16(const uint8_t *buffer, uint16_t &index);
 	float extractFloat16(const uint8_t *buffer, uint16_t &index);
 	int32_t extractInt32(const uint8_t *buffer, uint16_t &index);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -76,10 +76,14 @@ int main()
 				break;
 			case 't':
 				vesc_generator.requestValues();
+				printf("Voltage: %.3f\n", vesc_generator.getInputVoltage());
+				break;
+			case 'r':
+				vesc_generator.requestRpm();
+				printf("RPM: %.3f\n", vesc_generator.getRpm());
 				break;
 			}
 
-			printf("Voltage: %.3f\n", vesc_generator.getInputVoltage());
 			printf("Current: %.3f\n", current);
 		}
 


### PR DESCRIPTION
We only want to know e.g. the current rpm but use it in a fast paced control loop. VESC has a feature for that through a command called GET_VALUES_SELECTIVE, see https://github.com/vedderb/bldc/blob/3a071cee2f76db24308a9fb00b7d7482748ef73d/commands.c#L731-L749

I added support for this and fetching only rpm. It works in my bench test using VESC 6.